### PR TITLE
fix: :bug: leaderboar data duplicate

### DIFF
--- a/Assets/Scripts/Managers/UIManager.cs
+++ b/Assets/Scripts/Managers/UIManager.cs
@@ -144,7 +144,9 @@ public class UIManager : MonoBehaviour {
     }
 
     private void UpdateLeaderboardUI() {
-
+        
+        leadersNameUI.text = "";
+        leaderScoreUI.text = "";
         int counter = 1;
 
         foreach (Leaderboard leader in leaderboard) {


### PR DESCRIPTION
The leaderboard names and score was duplicate when you open the leaderboard

![image](https://github.com/JohanJimenex/Unity-Game-2D-Gender-Reveal/assets/48848092/76dde1bd-80d9-4b96-8577-b23de94c2d65)
